### PR TITLE
fix: json_encode() is discouraged

### DIFF
--- a/formbricks.php
+++ b/formbricks.php
@@ -293,7 +293,7 @@ function formbricks_enqueue_script() {
 				);
 
 				wp_add_inline_script( 'formbricks',
-					'const formbricksPluginSettings = ' . json_encode( array(
+					'const formbricksPluginSettings = ' . wp_json_encode( array(
 						'environmentId' => $environmentId,
 						'apiHost'       => $apiHost,
 					) ),


### PR DESCRIPTION
fixing wordpress plugin check error `json_encode() is discouraged`